### PR TITLE
[WIP] Added an optional config hash to the setup method

### DIFF
--- a/lib/doublesing.rb
+++ b/lib/doublesing.rb
@@ -16,7 +16,7 @@ module Doublesing
   # Assign a handler for a custom block class.
   # +name+: Name the block should respond to
   # +klass+: class the block should be generated from
-  # Note: 
+  # Note:
   def self.assign(name, klass)
     @@handlers[name] = klass
   end
@@ -28,8 +28,16 @@ module Doublesing
       ""
     end
   end
-  def self.setup!
+  def self.setup! configs = {}
     @@handlers = {}
     @@handlers.merge! Builtins.handlers
+    @@parse_configs = {
+        argument_begin: "{",
+        argument_end: "}"
+      }.merge! (configs[:parse] || {})
+  end
+
+  def self.parse_configs
+    @@parse_configs || {}
   end
 end

--- a/lib/doublesing/parser.rb
+++ b/lib/doublesing/parser.rb
@@ -1,8 +1,9 @@
 require 'parslet'
 module Doublesing
   class Parser < Parslet::Parser
-    rule(:argument_begin){ str("{") }
-    rule(:argument_end){ str("\\}").absent? >> str("}")}
+    rule(:argument_begin){ str(Doublesing.parse_configs[:argument_begin]) }
+    rule(:argument_end){
+      str("\\" + Doublesing.parse_configs[:argument_end]).absent? >> str(Doublesing.parse_configs[:argument_end])}
     rule(:block_begin){ str("\\\\").absent? >> str("\\")}
     rule(:block_id){ match["\\w"].repeat(1)}
     rule(:block_header){ block_begin >> block_id.as(:id)}

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,4 +1,5 @@
 require 'parslet/rig/rspec'
+Doublesing.setup!
 RSpec.describe Doublesing::Parser do
   let(:p){Doublesing::Parser.new}
   context "argument_begin" do


### PR DESCRIPTION
This is an idea on how to configure the parser to be able to use any delimiter one wishes for arguments.

So for example 

``` ruby
Doublesing.setup! :parse => { argument_begin: "[", argument_end: "]" }
```

now allows you to write `\bold[this is bold text]`

I am not a fan of how the settings are handled am happy to hear input on whether this feature would be a bad idea or how to do it better!
